### PR TITLE
Composer v2.9 compatibility

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,7 +103,7 @@ jobs:
     strategy:
       matrix:
         php-version: ${{ fromJSON(needs.php-matrix.outputs.versions) }}
-        composer-version: ['2.6', '2.7', '2.8']
+        composer-version: ['2.6', '2.7', '2.8', '2.9']
     runs-on: ubuntu-latest
     env:
       GOFLAGS: '-mod=mod'

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,11 @@
 export GOFLAGS=-mod=mod
 
 combos := php-8-composer-latest \
+	php-8.4-composer-2.9 \
 	php-8.4-composer-2.8 \
 	php-8.4-composer-2.7 \
 	php-8.4-composer-2.6 \
+	php-8.3-composer-2.9 \
 	php-8.3-composer-2.8 \
 	php-8.3-composer-2.7 \
 	php-8.3-composer-2.6

--- a/README.md
+++ b/README.md
@@ -161,6 +161,40 @@ If you must clear the cache, delete the `<composer-cache-dir>/wp-org-closed-plug
 rm -rf $(composer config cache-dir)/wp-org-closed-plugin
 ```
 
+### Why `allow_self_signed` when connecting to `https://api.wordpress.org`?
+
+> [!IMPORTANT]
+> **Help Wanted!**
+>
+> Please send pull requests if you know how to get around the error:
+>
+> ```console
+> $ curl --http3-only 'https://api.wordpress.org/plugins/info/1.2/?action=plugin_information&slug=better-delete-revision'
+> curl: (56) ngtcp2_conn_writev_stream returned error: ERR_DRAINING
+> ```
+
+It is a hack to disallow HTTP/3, forcing `HttpDownloader` to use `RemoteFilesystem` instead of `CurlDownloader`.
+
+I suspect api.wordpress.org does not properly support HTTP/3:
+
+```console
+$ curl --http1.1 'https://api.wordpress.org/plugins/info/1.2/?action=plugin_information&slug=better-delete-revision'
+...json response
+
+$ curl --http2 'https://api.wordpress.org/plugins/info/1.2/?action=plugin_information&slug=better-delete-revision'
+...json response
+
+$ curl --http3-only 'https://api.wordpress.org/plugins/info/1.2/?action=plugin_information&slug=better-delete-revision'
+...sometimes json response
+...but most of the time ERR_DRAINING
+curl: (56) ngtcp2_conn_writev_stream returned error: ERR_DRAINING
+```
+
+See:
+- https://github.com/composer/composer/pull/12363
+- https://github.com/composer/composer/blob/f5854b140ca27164d352ce30deece798acf3e36b/src/Composer/Util/HttpDownloader.php#L537
+- https://github.com/typisttech/wp-org-closed-plugin/pull/22
+
 > [!TIP]
 > **Hire Tang Rufus!**
 >

--- a/src/WpOrg/Api/Client.php
+++ b/src/WpOrg/Api/Client.php
@@ -12,6 +12,32 @@ use React\Promise\PromiseInterface;
 
 readonly class Client
 {
+    /**
+     * Hack to disallow HTTP/3, forcing HttpDownloader to use RemoteFilesystem instead of CurlDownloader.
+     *
+     * I suspect api.wordpress.org does not properly support HTTP/3:
+     *
+     *     $ curl --http1.1 'https://api.wordpress.org/plugins/info/1.2/?action=plugin_information&slug=better-delete-revision'
+     *     ...json response
+     *
+     *     $ curl --http2 'https://api.wordpress.org/plugins/info/1.2/?action=plugin_information&slug=better-delete-revision'
+     *     ...json response
+     *
+     *     $ curl --http3-only 'https://api.wordpress.org/plugins/info/1.2/?action=plugin_information&slug=better-delete-revision'
+     *     ...sometimes json response
+     *     ...but most of the time ERR_DRAINING
+     *     curl: (56) ngtcp2_conn_writev_stream returned error: ERR_DRAINING
+     *
+     * See:
+     *   - https://github.com/composer/composer/pull/12363
+     *   - https://github.com/composer/composer/blob/f5854b140ca27164d352ce30deece798acf3e36b/src/Composer/Util/HttpDownloader.php#L537
+     */
+    private const OPTIONS = [
+        'ssl' => [
+            'allow_self_signed' => true,
+        ],
+    ];
+
     public function __construct(
         private HttpDownloader $httpDownloader,
         private Loop $loop,
@@ -88,7 +114,7 @@ readonly class Client
             ], '', '&'),
         );
 
-        return $this->httpDownloader->add($url)
+        return $this->httpDownloader->add($url, self::OPTIONS)
             ->then(static fn () => null) // Ignore successful responses. Closed plugins always return 404.
             ->catch(static function (TransportException $e): ?string {
                 // Closed plugins always return 404.

--- a/testdata/script/install_dist_closed.txtar
+++ b/testdata/script/install_dist_closed.txtar
@@ -6,7 +6,6 @@ stderr -count=1 'Package wpackagist-plugin/better-delete-revision is abandoned'
 
 exec composer install
 
-stderr 'Nothing to install, update or remove'
 stderr -count=1 'Package wpackagist-plugin/better-delete-revision is abandoned'
 
 -- composer.json --

--- a/testdata/script/install_dist_open.txtar
+++ b/testdata/script/install_dist_open.txtar
@@ -6,7 +6,6 @@ exec composer install
 
 exec composer install
 
-stderr 'Nothing to install, update or remove'
 ! stderr abandoned
 
 -- composer.json --

--- a/testdata/script/require_dist_closed.txtar
+++ b/testdata/script/require_dist_closed.txtar
@@ -6,7 +6,6 @@ stderr -count=1 'Package wpackagist-plugin/better-delete-revision is abandoned'
 
 exec composer require wpackagist-plugin/better-delete-revision
 
-stderr 'Nothing to install, update or remove'
 stderr -count=1 'Package wpackagist-plugin/better-delete-revision is abandoned'
 
 -- composer.json --

--- a/testdata/script/require_dist_open.txtar
+++ b/testdata/script/require_dist_open.txtar
@@ -6,7 +6,6 @@ exec composer require wpackagist-plugin/hello-dolly
 
 exec composer require wpackagist-plugin/hello-dolly
 
-stderr 'Nothing to install, update or remove'
 ! stderr abandoned
 
 -- composer.json --

--- a/testdata/script/update_dist_closed.txtar
+++ b/testdata/script/update_dist_closed.txtar
@@ -6,7 +6,6 @@ stderr -count=1 'Package wpackagist-plugin/better-delete-revision is abandoned'
 
 exec composer update
 
-stderr 'Nothing to install, update or remove'
 stderr -count=1 'Package wpackagist-plugin/better-delete-revision is abandoned'
 
 -- composer.json --

--- a/testdata/script/update_dist_open.txtar
+++ b/testdata/script/update_dist_open.txtar
@@ -6,7 +6,6 @@ exec composer update
 
 exec composer update
 
-stderr 'Nothing to install, update or remove'
 ! stderr abandoned
 
 -- composer.json --


### PR DESCRIPTION
Hack to disallow HTTP/3, forcing `HttpDownloader` to use `RemoteFilesystem` instead of `CurlDownloader`.

I suspect api.wordpress.org does not properly support HTTP/3:

    $ curl --http1.1 'https://api.wordpress.org/plugins/info/1.2/?action=plugin_information&slug=better-delete-revision'
    ...json response

    $ curl --http2 'https://api.wordpress.org/plugins/info/1.2/?action=plugin_information&slug=better-delete-revision'
    ...json response

    $ curl --http3-only 'https://api.wordpress.org/plugins/info/1.2/?action=plugin_information&slug=better-delete-revision'
    ...sometimes json response
    ...but most of the time ERR_DRAINING
    curl: (56) ngtcp2_conn_writev_stream returned error: ERR_DRAINING

See:
  - https://github.com/composer/composer/pull/12363
  - https://github.com/composer/composer/blob/f5854b140ca27164d352ce30deece798acf3e36b/src/Composer/Util/HttpDownloader.php#L537

